### PR TITLE
Fix query for PR assignees

### DIFF
--- a/github/downloader.go
+++ b/github/downloader.go
@@ -545,15 +545,7 @@ func (d Downloader) downloadPullRequestAssignees(ctx context.Context, pr *graphq
 	variables := map[string]interface{}{
 		"id": githubv4.ID(pr.Id),
 
-		"assigneesPage":                 githubv4.Int(assigneesPage),
-		"issueCommentsPage":             githubv4.Int(issueCommentsPage),
-		"issuesPage":                    githubv4.Int(issuesPage),
-		"labelsPage":                    githubv4.Int(labelsPage),
-		"pullRequestReviewCommentsPage": githubv4.Int(pullRequestReviewCommentsPage),
-		"pullRequestReviewsPage":        githubv4.Int(pullRequestReviewsPage),
-		"pullRequestsPage":              githubv4.Int(pullRequestsPage),
-		"repositoryTopicsPage":          githubv4.Int(repositoryTopicsPage),
-
+		"assigneesPage":   githubv4.Int(assigneesPage),
 		"assigneesCursor": (*githubv4.String)(nil),
 	}
 


### PR DESCRIPTION
Found this error message while downloading `src-d` org:
```
failed to download repository src-d/guide: failed to process PR src-d/guide #336: failed to query PR assignees for PR #336: Variable $issueCommentsPage is declared by  but not used
```