### PR TITLE
Use int versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ To use, create a personal GitHub token with the scopes **read:org**, **repo**.
 export GITHUB_TOKEN=xxxx
 
 # Info for individual repositories
-go run examples/cmd/*.go repo --version v0 --owner=src-d --name=metadata-retrieval
+go run examples/cmd/*.go repo --version 0 --owner=src-d --name=metadata-retrieval
 
 # Info for individual organization and its users (not including its repositories)
-go run examples/cmd/*.go org --version v0 --name=src-d
+go run examples/cmd/*.go org --version 0 --name=src-d
 
 # Info for organization and all its repositories (similar to ghsync deep)
-go run examples/cmd/*.go ghsync --version v0 --name=src-d --no-forks
+go run examples/cmd/*.go ghsync --version 0 --name=src-d --no-forks
 ```
 
 To use a postgres DB:
@@ -24,7 +24,7 @@ To use a postgres DB:
 ```shell
 docker-compose up -d
 
-go run examples/cmd/*.go repo --version v0 --owner=src-d --name=metadata-retrieval --db=postgres://user:password@127.0.0.1:5432/ghsync?sslmode=disable
+go run examples/cmd/*.go repo --version 0 --owner=src-d --name=metadata-retrieval --db=postgres://user:password@127.0.0.1:5432/ghsync?sslmode=disable
 
 docker-compose exec postgres psql postgres://user:password@127.0.0.1:5432/ghsync?sslmode=disable -c "select * from pull_request_reviews"
 ```
@@ -36,8 +36,8 @@ You can see the diff between the current DB schema and the ghsync schema here:
 <details><summary>diff</summary>
 
 ```diff
---- doc/1560510971_initial_schema.up.sql	2019-09-25 11:15:06.037702240 +0100
-+++ database/migrations/000001_init.up.sql	2019-09-25 12:01:21.829358293 +0100
+--- doc/1560510971_initial_schema.up.sql	2019-09-30 10:28:28.569403577 +0100
++++ database/migrations/000001_init.up.sql	2019-09-30 12:27:48.783414881 +0100
 @@ -1,267 +1,251 @@
  BEGIN;
  
@@ -45,7 +45,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 -  kallax_id serial NOT NULL PRIMARY KEY,
 +CREATE TABLE IF NOT EXISTS organizations_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    avatar_url text,
    billing_email text,
@@ -80,7 +80,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 +
 +CREATE TABLE IF NOT EXISTS users_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    avatar_url text,
    bio text,
@@ -118,7 +118,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
  
 +CREATE TABLE IF NOT EXISTS repositories_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
 +  
    allow_merge_commit boolean,
    allow_rebase_merge boolean,
@@ -183,7 +183,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 -  assignees jsonb NOT NULL,
 +CREATE TABLE IF NOT EXISTS issues_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
 +
 +  assignees text[] NOT NULL,
    body text,
@@ -216,7 +216,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 +
 +CREATE TABLE IF NOT EXISTS issue_comments_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    author_association text,
    body text,
@@ -239,7 +239,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 +
 +CREATE TABLE IF NOT EXISTS pull_requests_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    additions bigint,
 -  assignee_id bigint NOT NULL,
@@ -300,7 +300,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 +
 +CREATE TABLE IF NOT EXISTS pull_request_reviews_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    body text,
    commit_id text,
@@ -328,7 +328,7 @@ You can see the diff between the current DB schema and the ghsync schema here:
 +*/
 +CREATE TABLE IF NOT EXISTS pull_request_comments_versioned (
 +  sum256 character varying(64) PRIMARY KEY,
-+  versions text ARRAY,
++  versions integer ARRAY,
  
    author_association text,
    body text,

--- a/database/migrations/000001_init.up.sql
+++ b/database/migrations/000001_init.up.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS organizations_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   avatar_url text,
   billing_email text,
@@ -27,7 +27,7 @@ CREATE INDEX IF NOT EXISTS organizations_versions ON organizations_versioned (ve
 
 CREATE TABLE IF NOT EXISTS users_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   avatar_url text,
   bio text,
@@ -56,7 +56,7 @@ CREATE INDEX IF NOT EXISTS users_versions ON users_versioned (versions);
 
 CREATE TABLE IF NOT EXISTS repositories_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
   
   allow_merge_commit boolean,
   allow_rebase_merge boolean,
@@ -96,7 +96,7 @@ CREATE INDEX IF NOT EXISTS repositories_versions ON repositories_versioned (vers
 
 CREATE TABLE IF NOT EXISTS issues_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   assignees text[] NOT NULL,
   body text,
@@ -126,7 +126,7 @@ CREATE INDEX IF NOT EXISTS issues_versions ON issues_versioned (versions);
 
 CREATE TABLE IF NOT EXISTS issue_comments_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   author_association text,
   body text,
@@ -146,7 +146,7 @@ CREATE INDEX IF NOT EXISTS issue_comments_versions ON issue_comments_versioned (
 
 CREATE TABLE IF NOT EXISTS pull_requests_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   additions bigint,
   assignees text[] NOT NULL,
@@ -196,7 +196,7 @@ CREATE INDEX IF NOT EXISTS pull_requests_versions ON pull_requests_versioned (ve
 
 CREATE TABLE IF NOT EXISTS pull_request_reviews_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   body text,
   commit_id text,
@@ -222,7 +222,7 @@ pull_request_review_comments
 */
 CREATE TABLE IF NOT EXISTS pull_request_comments_versioned (
   sum256 character varying(64) PRIMARY KEY,
-  versions text ARRAY,
+  versions integer ARRAY,
 
   author_association text,
   body text,

--- a/examples/cmd/main.go
+++ b/examples/cmd/main.go
@@ -35,7 +35,7 @@ type DownloaderCmd struct {
 
 	DB      string `long:"db" description:"PostgreSQL URL connection string, e.g. postgres://user:password@127.0.0.1:5432/ghsync?sslmode=disable"`
 	Token   string `long:"token" short:"t" env:"GITHUB_TOKEN" description:"GitHub personal access token" required:"true"`
-	Version string `long:"version" description:"Version tag in the DB"`
+	Version int    `long:"version" description:"Version tag in the DB"`
 	Cleanup bool   `long:"cleanup" description:"Do a garbage collection on the DB, deleting data from other versions"`
 }
 
@@ -48,10 +48,6 @@ type Repository struct {
 }
 
 func (c *Repository) Execute(args []string) error {
-	if c.Version == "" {
-		c.Version = time.Now().Format("2006-01-02 15:04:05")
-	}
-
 	return c.ExecuteBody(
 		log.New(log.Fields{"owner": c.Owner, "repo": c.Name}),
 		func(httpClient *http.Client, downloader *github.Downloader) error {
@@ -67,10 +63,6 @@ type Organization struct {
 }
 
 func (c *Organization) Execute(args []string) error {
-	if c.Version == "" {
-		c.Version = time.Now().Format("2006-01-02 15:04:05")
-	}
-
 	return c.ExecuteBody(
 		log.New(log.Fields{"org": c.Name}),
 		func(httpClient *http.Client, downloader *github.Downloader) error {
@@ -87,10 +79,6 @@ type Ghsync struct {
 }
 
 func (c *Ghsync) Execute(args []string) error {
-	if c.Version == "" {
-		c.Version = time.Now().Format("2006-01-02 15:04:05")
-	}
-
 	return c.ExecuteBody(
 		log.New(log.Fields{"org": c.Name}),
 		func(httpClient *http.Client, downloader *github.Downloader) error {

--- a/github/downloader.go
+++ b/github/downloader.go
@@ -38,9 +38,9 @@ type storer interface {
 	Begin() error
 	Commit() error
 	Rollback() error
-	Version(v string)
-	SetActiveVersion(v string) error
-	Cleanup(currentVersion string) error
+	Version(v int)
+	SetActiveVersion(v int) error
+	Cleanup(currentVersion int) error
 }
 
 // Downloader fetches GitHub data using the v4 API
@@ -81,7 +81,7 @@ func NewStdoutDownloader(httpClient *http.Client) (*Downloader, error) {
 
 // DownloadRepository downloads the metadata for the given repository and all
 // its resources (issues, PRs, comments, reviews)
-func (d Downloader) DownloadRepository(ctx context.Context, owner string, name string, version string) error {
+func (d Downloader) DownloadRepository(ctx context.Context, owner string, name string, version int) error {
 	d.storer.Version(version)
 
 	var err error
@@ -806,7 +806,7 @@ func (d Downloader) downloadReviewComments(ctx context.Context, repositoryOwner,
 
 // DownloadOrganization downloads the metadata for the given organization and
 // its member users
-func (d Downloader) DownloadOrganization(ctx context.Context, name string, version string) error {
+func (d Downloader) DownloadOrganization(ctx context.Context, name string, version int) error {
 	d.storer.Version(version)
 
 	var err error
@@ -917,7 +917,7 @@ func (d Downloader) downloadUsers(ctx context.Context, name string, organization
 }
 
 // SetCurrent enables the given version as the current one accessible in the DB
-func (d Downloader) SetCurrent(version string) error {
+func (d Downloader) SetCurrent(version int) error {
 	err := d.storer.SetActiveVersion(version)
 	if err != nil {
 		return fmt.Errorf("failed to set current DB version to %v: %v", version, err)
@@ -926,7 +926,7 @@ func (d Downloader) SetCurrent(version string) error {
 }
 
 // Cleanup deletes from the DB all records that do not belong to the currentVersion
-func (d Downloader) Cleanup(currentVersion string) error {
+func (d Downloader) Cleanup(currentVersion int) error {
 	err := d.storer.Cleanup(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to do cleanup for DB version %v: %v", currentVersion, err)

--- a/github/store/stdout.go
+++ b/github/store/stdout.go
@@ -65,14 +65,14 @@ func (s *Stdout) Rollback() error {
 	return nil
 }
 
-func (s *Stdout) Version(v string) {
+func (s *Stdout) Version(v int) {
 }
 
-func (s *Stdout) SetActiveVersion(v string) error {
+func (s *Stdout) SetActiveVersion(v int) error {
 	return nil
 }
 
-func (s *Stdout) Cleanup(currentVersion string) error {
+func (s *Stdout) Cleanup(currentVersion int) error {
 	return nil
 }
 


### PR DESCRIPTION
Fix #11.

I had to change the syntax for the insert because `array[$2]` was sent as a text array, and it failed with:
`failed to save repository carlosms-test-org/test-repo: saveRepository: pq: column "versions" is of type integer[] but expression is of type text[]`