### PR TITLE
Adds parallel fetch for repositories

### DIFF
--- a/github/retry.go
+++ b/github/retry.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -52,6 +53,10 @@ func retry(f func() error) error {
 		err := f()
 		if err == nil {
 			return nil
+		}
+
+		if err == context.Canceled {
+			return err
 		}
 
 		if i == retries {


### PR DESCRIPTION
Closes #10.

Adds parallel fetch for repositories along with a flag to set the maximum number of concurrent repositories being downloaded. To keep the same behavior, if a repository fails being downloaded, the running fetches are stopped and the program exits.

Here's a screenshot of a run with a fake error during the download of `enry` repo for `src-d` org:

<img width="1440" alt="Screenshot 2019-09-30 at 17 14 20" src="https://user-images.githubusercontent.com/5599208/65891992-cf632100-e3a5-11e9-8f44-0c4ac1f7ca11.png">
