### PR TITLE
Add logging

### DIFF
--- a/examples/cmd/main.go
+++ b/examples/cmd/main.go
@@ -121,7 +121,7 @@ func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 	if c.DB == "" {
 		log.Infof("using stdout to save the data")
 		var err error
-		downloader, err = github.NewStdoutDownloader(logger, client)
+		downloader, err = github.NewStdoutDownloader(client)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 			return err
 		}
 
-		downloader, err = github.NewDownloader(logger, client, db)
+		downloader, err = github.NewDownloader(client, db)
 	}
 
 	rate0, err := downloader.RateRemaining(context.TODO())

--- a/examples/cmd/main.go
+++ b/examples/cmd/main.go
@@ -50,7 +50,7 @@ type Repository struct {
 func (c *Repository) Execute(args []string) error {
 	return c.ExecuteBody(
 		log.New(log.Fields{"owner": c.Owner, "repo": c.Name}),
-		func(httpClient *http.Client, downloader *github.Downloader) error {
+		func(logger log.Logger, httpClient *http.Client, downloader *github.Downloader) error {
 			return downloader.DownloadRepository(context.TODO(), c.Owner, c.Name, c.Version)
 		})
 }
@@ -65,7 +65,7 @@ type Organization struct {
 func (c *Organization) Execute(args []string) error {
 	return c.ExecuteBody(
 		log.New(log.Fields{"org": c.Name}),
-		func(httpClient *http.Client, downloader *github.Downloader) error {
+		func(logger log.Logger, httpClient *http.Client, downloader *github.Downloader) error {
 			return downloader.DownloadOrganization(context.TODO(), c.Name, c.Version)
 		})
 }
@@ -81,7 +81,7 @@ type Ghsync struct {
 func (c *Ghsync) Execute(args []string) error {
 	return c.ExecuteBody(
 		log.New(log.Fields{"org": c.Name}),
-		func(httpClient *http.Client, downloader *github.Downloader) error {
+		func(logger log.Logger, httpClient *http.Client, downloader *github.Downloader) error {
 			repos, err := listRepositories(context.TODO(), httpClient, c.Name, c.NoForks)
 			if err != nil {
 				return err
@@ -92,11 +92,13 @@ func (c *Ghsync) Execute(args []string) error {
 				return fmt.Errorf("failed to download organization %v: %v", c.Name, err)
 			}
 
-			for _, repo := range repos {
+			for i, repo := range repos {
+				logger.Infof("start downloading '%s'", repo)
 				err = downloader.DownloadRepository(context.TODO(), c.Name, repo, c.Version)
 				if err != nil {
 					return fmt.Errorf("failed to download repository %v/%v: %v", c.Name, repo, err)
 				}
+				logger.Infof("finished downloading '%s' (%d/%d)", repo, i+1, len(repos))
 			}
 
 			return nil
@@ -104,7 +106,7 @@ func (c *Ghsync) Execute(args []string) error {
 		})
 }
 
-type bodyFunc = func(httpClient *http.Client, downloader *github.Downloader) error
+type bodyFunc = func(logger log.Logger, httpClient *http.Client, downloader *github.Downloader) error
 
 func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 	client := oauth2.NewClient(context.TODO(), oauth2.StaticTokenSource(
@@ -119,7 +121,7 @@ func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 	if c.DB == "" {
 		log.Infof("using stdout to save the data")
 		var err error
-		downloader, err = github.NewStdoutDownloader(client)
+		downloader, err = github.NewStdoutDownloader(logger, client)
 		if err != nil {
 			return err
 		}
@@ -144,7 +146,7 @@ func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 			return err
 		}
 
-		downloader, err = github.NewDownloader(client, db)
+		downloader, err = github.NewDownloader(logger, client, db)
 	}
 
 	rate0, err := downloader.RateRemaining(context.TODO())
@@ -153,7 +155,7 @@ func (c *DownloaderCmd) ExecuteBody(logger log.Logger, fn bodyFunc) error {
 	}
 	t0 := time.Now()
 
-	err = fn(client, downloader)
+	err = fn(logger, client, downloader)
 	if err != nil {
 		return err
 	}

--- a/github/downloader_test.go
+++ b/github/downloader_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-	"gopkg.in/src-d/go-log.v1"
 )
 
 // RepositoryTest struct to hold a test oracle for a repository
@@ -72,9 +71,7 @@ func loadOnlineTests(filepath string) (OnlineTests, error) {
 }
 
 func getDownloader() (*Downloader, *testutils.Memory, error) {
-	logger := log.New(nil)
 	downloader, err := NewStdoutDownloader(
-		logger,
 		oauth2.NewClient(
 			context.TODO(),
 			oauth2.StaticTokenSource(

--- a/github/downloader_test.go
+++ b/github/downloader_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	"gopkg.in/src-d/go-log.v1"
 )
 
 // RepositoryTest struct to hold a test oracle for a repository
@@ -71,7 +72,9 @@ func loadOnlineTests(filepath string) (OnlineTests, error) {
 }
 
 func getDownloader() (*Downloader, *testutils.Memory, error) {
+	logger := log.New(nil)
 	downloader, err := NewStdoutDownloader(
+		logger,
 		oauth2.NewClient(
 			context.TODO(),
 			oauth2.StaticTokenSource(

--- a/github/graphql/types.go
+++ b/github/graphql/types.go
@@ -2,6 +2,12 @@ package graphql
 
 import "time"
 
+// Connection represents common fields for paginated the connections
+type Connection struct {
+	PageInfo   PageInfo
+	TotalCount int
+}
+
 // PageInfo represents https://developer.github.com/v4/object/pageinfo/
 type PageInfo struct {
 	HasNextPage bool
@@ -45,9 +51,8 @@ type OrganizationFields struct {
 
 // OrganizationMemberConnection represents https://developer.github.com/v4/object/organizationmemberconnection/
 type OrganizationMemberConnection struct {
-	TotalCount int
-	PageInfo   PageInfo
-	Nodes      []UserExtended
+	Connection
+	Nodes []UserExtended
 } // `graphql:"membersWithRole(first: $membersWithRolePage, after: $membersWithRoleCursor)"`
 
 // UserExtended is the same type as User, but requesting more fields.
@@ -158,8 +163,8 @@ type RepositoryFields struct {
 
 // RepositoryTopicsConnection represents https://developer.github.com/v4/object/repositorytopicconnection/
 type RepositoryTopicsConnection struct {
-	PageInfo PageInfo
-	Nodes    []struct {
+	Connection
+	Nodes []struct {
 		Topic struct {
 			Name string
 		}
@@ -168,14 +173,13 @@ type RepositoryTopicsConnection struct {
 
 // IssueConnection represents https://developer.github.com/v4/object/issueconnection/
 type IssueConnection struct {
-	PageInfo PageInfo
-	Nodes    []Issue
+	Connection
+	Nodes []Issue
 } //`graphql:"issues(first: $issuesPage, after: $issuesCursor)"`
 
 type IssueCommentsConnection struct {
-	TotalCount int
-	PageInfo   PageInfo
-	Nodes      []IssueComment
+	Connection
+	Nodes []IssueComment
 } // `graphql:"comments(first: $issueCommentsPage, after: $issueCommentsCursor)"`
 
 // Issue represents https://developer.github.com/v4/object/issue/
@@ -229,8 +233,8 @@ type ClosedByConnection struct {
 
 // UserConnection represents https://developer.github.com/v4/object/userconnection/
 type UserConnection struct {
-	PageInfo PageInfo
-	Nodes    []User
+	Connection
+	Nodes []User
 } //`graphql:"assignees(first: $assigneesPage, after: $assigneesCursor)"`
 
 // Label represents https://developer.github.com/v4/object/label/
@@ -240,8 +244,8 @@ type Label struct {
 
 // LabelConnection represents https://developer.github.com/v4/object/labelconnection/
 type LabelConnection struct {
-	PageInfo PageInfo
-	Nodes    []Label
+	Connection
+	Nodes []Label
 } //`graphql:"labels(first: $labelsPage, after: $labelsCursor)"`
 
 type IssueComment struct {
@@ -256,8 +260,8 @@ type IssueComment struct {
 }
 
 type PullRequestConnection struct {
-	PageInfo PageInfo
-	Nodes    []PullRequest
+	Connection
+	Nodes []PullRequest
 } //`graphql:"pullRequests(first: $pullRequestsPage, after: $pullRequestsCursor)"`
 
 type PullRequest struct {
@@ -327,9 +331,8 @@ type PullRequestFields struct {
 }
 
 type PullRequestReviewConnection struct {
-	//TotalCount int
-	PageInfo PageInfo
-	Nodes    []PullRequestReview
+	Connection
+	Nodes []PullRequestReview
 } // `graphql:"reviews(first: $pullRequestReviewsPage, after: $pullRequestReviewsCursor)"`
 
 type PullRequestReview struct {
@@ -353,9 +356,8 @@ type PullRequestReviewFields struct {
 }
 
 type PullRequestReviewCommentConnection struct {
-	//TotalCount int
-	PageInfo PageInfo
-	Nodes    []PullRequestReviewComment
+	Connection
+	Nodes []PullRequestReviewComment
 }
 
 type PullRequestReviewComment struct {

--- a/utils/ctxlog/context.go
+++ b/utils/ctxlog/context.go
@@ -1,0 +1,70 @@
+package ctxlog
+
+import (
+	"context"
+
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// NewLogger function to create new log.Logger, needed for mocking in tests
+var NewLogger = log.New
+
+type ctxKey int
+
+// logFieldsKey is the key that holds log Fields in a context.
+const logFieldsKey ctxKey = 0
+
+// Get returns a logger configured with the context log Fields or the default fields
+func Get(ctx context.Context) log.Logger {
+	var fields log.Fields
+
+	if v := ctx.Value(logFieldsKey); v != nil {
+		fields = v.(log.Fields)
+	}
+
+	return NewLogger(fields)
+}
+
+// Fields returns a copy of the context log fields. It can be nil
+func Fields(ctx context.Context) log.Fields {
+	if v := ctx.Value(logFieldsKey); v != nil {
+		f := v.(log.Fields)
+		copy := make(map[string]interface{}, len(f))
+
+		for key, val := range f {
+			copy[key] = val
+		}
+
+		return copy
+	}
+
+	return nil
+}
+
+// WithLogFields returns a context with new logger Fields added to the current
+// ones, and a logger
+func WithLogFields(ctx context.Context, fields log.Fields) (context.Context, log.Logger) {
+	if fields == nil {
+		return ctx, Get(ctx)
+	}
+
+	newFields := make(map[string]interface{}, len(fields))
+
+	if v := ctx.Value(logFieldsKey); v != nil {
+		for key, val := range v.(log.Fields) {
+			newFields[key] = val
+		}
+	}
+
+	for key, val := range fields {
+		newFields[key] = val
+	}
+
+	ctx = set(ctx, newFields)
+	return ctx, Get(ctx)
+}
+
+// set returns a copy of ctx with the log Fields saves as context Value
+func set(ctx context.Context, fields log.Fields) context.Context {
+	return context.WithValue(ctx, logFieldsKey, fields)
+}

--- a/utils/ctxlog/context_test.go
+++ b/utils/ctxlog/context_test.go
@@ -1,0 +1,93 @@
+package ctxlog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	log "gopkg.in/src-d/go-log.v1"
+
+	"github.com/src-d/metadata-retrieval/utils/ctxlog"
+)
+
+func TestEmptyGet(t *testing.T) {
+	ctx := context.Background()
+
+	log := ctxlog.Get(ctx)
+
+	require.NotNil(t, log)
+
+	require.NotPanics(t, func() {
+		log.Debugf("a test log msg")
+	})
+}
+
+func TestNilFields(t *testing.T) {
+	ctx := context.Background()
+
+	fields := ctxlog.Fields(ctx)
+
+	require.Nil(t, fields)
+}
+
+func TestWithLogFields(t *testing.T) {
+	ctxA := context.Background()
+	ctxAB, _ := ctxlog.WithLogFields(ctxA, log.Fields{"keyB": "valB"})
+	ctxABC, _ := ctxlog.WithLogFields(ctxAB, log.Fields{"keyC": "valC"})
+	ctxABD, _ := ctxlog.WithLogFields(ctxAB, log.Fields{"keyD": "valD"})
+
+	fieldsA := ctxlog.Fields(ctxA)
+	fieldsB := ctxlog.Fields(ctxAB)
+	fieldsC := ctxlog.Fields(ctxABC)
+	fieldsD := ctxlog.Fields(ctxABD)
+
+	require.NotEqual(t, fieldsA, fieldsB)
+	require.NotEqual(t, fieldsB, fieldsC)
+
+	require.Nil(t, fieldsA["keyB"])
+	require.Nil(t, fieldsA["keyC"])
+	require.Nil(t, fieldsA["keyD"])
+
+	require.Equal(t, "valB", fieldsB["keyB"])
+	require.Nil(t, fieldsB["keyC"])
+	require.Nil(t, fieldsB["keyD"])
+
+	require.Equal(t, "valB", fieldsC["keyB"])
+	require.Equal(t, "valC", fieldsC["keyC"])
+	require.Nil(t, fieldsC["keyD"])
+
+	require.Equal(t, "valB", fieldsD["keyB"])
+	require.Nil(t, fieldsD["keyC"])
+	require.Equal(t, "valD", fieldsD["keyD"])
+}
+
+func TestWithNilLogFields(t *testing.T) {
+	ctxA := context.Background()
+
+	ctxB, logger := ctxlog.WithLogFields(ctxA, nil)
+
+	require.NotNil(t, ctxB)
+	require.NotNil(t, logger)
+}
+
+func TestReadOnlyWithLogFields(t *testing.T) {
+	ctxA := context.Background()
+	ctxB, _ := ctxlog.WithLogFields(ctxA, log.Fields{"keyB": "valB"})
+
+	fieldsA := ctxlog.Fields(ctxA)
+	fieldsB := ctxlog.Fields(ctxB)
+
+	require.Nil(t, fieldsA["keyB"])
+	require.Equal(t, "valB", fieldsB["keyB"])
+
+	fieldsB["keyY"] = "valY"
+
+	fieldsA2 := ctxlog.Fields(ctxA)
+	fieldsB2 := ctxlog.Fields(ctxB)
+
+	require.Nil(t, fieldsA2["keyB"])
+	require.Nil(t, fieldsA2["keyY"])
+
+	require.Equal(t, "valB", fieldsB2["keyB"])
+	require.Nil(t, fieldsB2["keyY"])
+}


### PR DESCRIPTION
Fix: #8

- Refactor types to introduce common Connection struct which is used
here and will be needed for better pagination later
- Add package for getting logger from context
- CLI: start/finish of repository download with progress like (1/10)
- Lib start/finish for:
  - Topics
  - Pull Requests
  - Issues
  - Users
  - Log issues and pull requests while downloading them for big
repositories. That is enough to see progress. For even more granular logging it's still possible to use `--log-http`.


Example of `ghsync` command:
```
$ go run examples/cmd/*.go ghsync --name go-chi --db="postgres://smacker@127.0.0.1:5432/ghsync?sslmode=disable"
[2019-10-09T17:35:57.965964+02:00]  INFO start downloading users owner=go-chi
[2019-10-09T17:35:57.968538+02:00]  INFO finished downloading users owner=go-chi
[2019-10-09T17:35:57.970786+02:00]  INFO start downloading 'jsonp' org=go-chi
[2019-10-09T17:35:58.576544+02:00]  INFO start downloading topics owner=go-chi repo=jsonp
[2019-10-09T17:35:58.576614+02:00]  INFO finished downloading topics owner=go-chi repo=jsonp
[2019-10-09T17:35:58.578679+02:00]  INFO start downloading issues owner=go-chi repo=jsonp
[2019-10-09T17:35:58.578736+02:00]  INFO finished downloading issues owner=go-chi repo=jsonp
[2019-10-09T17:35:58.578769+02:00]  INFO start downloading pull requests owner=go-chi repo=jsonp
[2019-10-09T17:35:58.578798+02:00]  INFO finished downloading pull requests owner=go-chi repo=jsonp
[2019-10-09T17:35:58.580895+02:00]  INFO finished downloading 'jsonp' (1/9) org=go-chi
[2019-10-09T17:35:58.580941+02:00]  INFO start downloading 'httpcoala' org=go-chi
[2019-10-09T17:35:59.501675+02:00]  INFO start downloading topics owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.501736+02:00]  INFO finished downloading topics owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.504011+02:00]  INFO start downloading issues owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.507021+02:00]  INFO finished downloading issues owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.507095+02:00]  INFO start downloading pull requests owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.518026+02:00]  INFO finished downloading pull requests owner=go-chi repo=httpcoala
[2019-10-09T17:35:59.520149+02:00]  INFO finished downloading 'httpcoala' (2/9) org=go-chi
[2019-10-09T17:35:59.520221+02:00]  INFO start downloading 'chi' org=go-chi
[2019-10-09T17:36:07.216378+02:00]  INFO start downloading topics owner=go-chi repo=chi
[2019-10-09T17:36:07.216438+02:00]  INFO finished downloading topics owner=go-chi repo=chi
[2019-10-09T17:36:07.232499+02:00]  INFO start downloading issues owner=go-chi repo=chi
[2019-10-09T17:36:18.307483+02:00]  INFO 150/263 issues downloaded owner=go-chi repo=chi
[2019-10-09T17:36:27.235098+02:00]  INFO finished downloading issues owner=go-chi repo=chi
[2019-10-09T17:36:27.235176+02:00]  INFO start downloading pull requests owner=go-chi repo=chi
[2019-10-09T17:36:44.00633+02:00]  INFO 150/193 pull requests downloaded owner=go-chi repo=chi
[2019-10-09T17:36:49.138767+02:00]  INFO finished downloading pull requests owner=go-chi repo=chi
[2019-10-09T17:36:49.140541+02:00]  INFO finished downloading 'chi' (3/9) org=go-chi
[2019-10-09T17:36:49.141861+02:00]  INFO start downloading 'jwtauth' org=go-chi
```

Example of `repo` command with a big repo:
```
$ go run examples/cmd/*.go repo --name=go-git --owner=src-d --db="postgres://smacker@127.0.0.1:5432/ghsync?sslmode=disable"
[2019-10-09T17:33:30.930486+02:00]  INFO start downloading topics owner=src-d repo=go-git
[2019-10-09T17:33:30.93066+02:00]  INFO finished downloading topics owner=src-d repo=go-git
[2019-10-09T17:33:30.935729+02:00]  INFO start downloading issues owner=src-d repo=go-git
[2019-10-09T17:33:45.645094+02:00]  INFO 150/554 issues downloaded owner=src-d repo=go-git
[2019-10-09T17:34:02.466357+02:00]  INFO 300/554 issues downloaded owner=src-d repo=go-git
[2019-10-09T17:34:13.982111+02:00]  INFO 450/554 issues downloaded owner=src-d repo=go-git
[2019-10-09T17:34:20.279796+02:00]  INFO finished downloading issues owner=src-d repo=go-git
[2019-10-09T17:34:20.279889+02:00]  INFO start downloading pull requests owner=src-d repo=go-git
[2019-10-09T17:35:12.811007+02:00]  INFO 150/663 pull requests downloaded owner=src-d repo=go-git
...
```


---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
