### PR TITLE
Handle RateLimit and Abuse errors

### DIFF
--- a/examples/cmd/main.go
+++ b/examples/cmd/main.go
@@ -318,6 +318,9 @@ func (c *DownloaderCmd) buildDownloadersPool(logger log.Logger, db *sql.DB) (*Do
 			setLogTransport(client, logger)
 		}
 
+		github.SetRateLimitTransport(client, logger)
+		github.SetRetryTransport(client)
+
 		var d *github.Downloader
 		var err error
 		if db == nil {

--- a/github/downloader.go
+++ b/github/downloader.go
@@ -65,11 +65,6 @@ type Downloader struct {
 // in the given DB. The HTTP client is expected to have the proper
 // authentication setup
 func NewDownloader(httpClient *http.Client, db *sql.DB) (*Downloader, error) {
-	// TODO: is the ghsync rate limited client needed?
-
-	t := &retryTransport{httpClient.Transport}
-	httpClient.Transport = t
-
 	return &Downloader{
 		storer: &store.DB{DB: db},
 		client: githubv4.NewClient(httpClient),
@@ -80,11 +75,6 @@ func NewDownloader(httpClient *http.Client, db *sql.DB) (*Downloader, error) {
 // metadata to stdout. The HTTP client is expected to have the proper
 // authentication setup
 func NewStdoutDownloader(httpClient *http.Client) (*Downloader, error) {
-	// TODO: is the ghsync rate limited client needed?
-
-	t := &retryTransport{httpClient.Transport}
-	httpClient.Transport = t
-
 	return &Downloader{
 		storer: &store.Stdout{},
 		client: githubv4.NewClient(httpClient),

--- a/github/httpbody.go
+++ b/github/httpbody.go
@@ -1,0 +1,20 @@
+package github
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// readResponseAndRestore reads the response.Body and restore it with the same content
+func readResponseAndRestore(resp *http.Response) ([]byte, error) {
+	bodyContent, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read the HTTP %d response: %s", resp.StatusCode, err)
+	}
+
+	resp.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+	return bodyContent, nil
+}

--- a/github/ratelimit.go
+++ b/github/ratelimit.go
@@ -1,0 +1,220 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/src-d/go-log.v1"
+)
+
+var (
+	// defaultAbuseRetryAfter is used when an Abuse is returned, but without 'Retry-After' header
+	// this value of 60s is usually returned by GitHub when they trigger the Abuse mechanism
+	defaultAbuseRetryAfter = time.Minute
+)
+
+// RateLimitTransport implements GitHub GraphQL API v4 best practices for avoiding rate limits
+// https://developer.github.com/v4/guides/resource-limitations/#rate-limit
+// https://developer.github.com/v3/#abuse-rate-limits
+// RateLimitTransport will process a Request, and if the response could not be fetched
+// because of a RateLimit or an AbuseRateLimit, it will return an ErrorRateLimit
+// and it no longer process any further Requests until the Limit has been expired.
+// RateLimitTransport does not retry; that behaviour must be implemented by another Transport
+// Each client (with its own token) should use its own RateLimitTransport
+type RateLimitTransport struct {
+	sync.Mutex
+
+	transport         http.RoundTripper
+	lockedUntil       time.Time
+	logger            log.Logger
+	defaultAbuseSleep time.Duration
+}
+
+// SetRateLimitTransport wraps the passed client.Transport with a RateLimitTransport
+func SetRateLimitTransport(client *http.Client, logger log.Logger) {
+	client.Transport = NewRateLimitTransport(client.Transport, logger)
+}
+
+// NewRateLimitTransport returns a new NewRateLimitTransport, who will call the passed
+// http.RoundTripper to process the http.Request
+// Each client (with its own token) should use its own RateLimitTransport
+func NewRateLimitTransport(rt http.RoundTripper, logger log.Logger) *RateLimitTransport {
+	return &RateLimitTransport{
+		transport:         rt,
+		logger:            logger,
+		defaultAbuseSleep: defaultAbuseRetryAfter,
+	}
+}
+
+// RoundTrip executes a single HTTP transaction, returning a Response for the provided Request.
+// If the request hitted an API RateLimit or Abuse, it will return an ErrorRateLimit
+// and it no longer process any further Requests until the Limit has been expired.
+func (rt *RateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Make Requests serially
+	rt.Lock()
+	defer rt.Unlock()
+
+	if time.Now().Before(rt.lockedUntil) {
+		rt.logger.Infof("rate limit reached, sleeping until %s", rt.lockedUntil)
+		time.Sleep(rt.lockedUntil.Sub(time.Now()))
+	}
+
+	resp, err := rt.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if errRateLimit := checkResponseRateLimit(resp, rt.logger, rt.defaultAbuseSleep); errRateLimit != nil {
+		rt.lockedUntil = errRateLimit.when()
+		rt.logger.Warningf("locking transport for %s; %s", errRateLimit.when().Sub(time.Now()), errRateLimit)
+		return resp, errRateLimit
+	}
+
+	return resp, nil
+}
+
+// checkRateLimit checks the API response and returns a whener error if a rate limit was found:
+// - *ErrRateLimit is returned when the request failed because of a RateLimit
+//    https://developer.github.com/v4/guides/resource-limitations/#rate-limit
+// - *ErrAbuseRateLimit is returned when the request triggered a GitHub abuse detection mechanism
+//    https://developer.github.com/v3/#abuse-rate-limits
+func checkResponseRateLimit(resp *http.Response, logger log.Logger, defaultAbuseSleep time.Duration) whener {
+	if err := asErrRateLimit(resp); err != nil {
+		return err
+	}
+
+	if err := asErrAbuseRateLimit(resp, logger, defaultAbuseSleep); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ErrRateLimit is returned when a request failed because of a RateLimit
+// https://developer.github.com/v4/guides/resource-limitations/#rate-limit
+type ErrRateLimit struct {
+	errRetryLater
+}
+
+func (e *ErrRateLimit) Error() string {
+	return fmt.Sprintf("API rate limit exceeded; %s", e.errRetryLater.Error())
+}
+
+// ErrAbuseRateLimit is returned when a request triggers any GitHub abuse detection mechanism
+// https://developer.github.com/v3/#abuse-rate-limits
+type ErrAbuseRateLimit struct {
+	errRetryLater
+}
+
+func (e *ErrAbuseRateLimit) Error() string {
+	return fmt.Sprintf("abuse detection mechanism triggered; %s", e.errRetryLater.Error())
+}
+
+type errRetryLater struct {
+	retryAfter time.Time
+}
+
+func (e *errRetryLater) Error() string {
+	return fmt.Sprintf("retry after %s", e.retryAfter)
+}
+
+func (e *errRetryLater) when() time.Time {
+	return e.retryAfter
+}
+
+type whener interface {
+	error
+	when() time.Time
+}
+
+/*
+An apiErrorResponse reports one or more errors caused by an API request.
+GitHub API docs: https://developer.github.com/v3/#client-errors
+Certain errors in graphql can come up in the body of the message with a 200 OK status
+https://graphql.github.io/graphql-spec/June2018/#sec-Errors
+*/
+type apiErrorResponse struct {
+	Message          string `json:"message,omitempty"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
+	Errors           []struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+func (aer *apiErrorResponse) isAbuseRateLimit() bool {
+	return strings.Contains(aer.DocumentationURL, "abuse") ||
+		strings.Contains(aer.Message, "abuse detection")
+}
+
+// asErrAbuseRateLimit returns ErrAbuseRateLimit when abuse was detected
+// it sets default value sleeping time if github didn't return any
+func asErrAbuseRateLimit(resp *http.Response, logger log.Logger, defaultSleep time.Duration) *ErrAbuseRateLimit {
+	if resp.StatusCode != http.StatusForbidden {
+		return nil
+	}
+
+	retryInHeader := resp.Header.Get("Retry-After")
+	retryIn, err := strconv.Atoi(retryInHeader)
+	if err == nil {
+		return &ErrAbuseRateLimit{
+			errRetryLater{time.Now().Add(time.Duration(retryIn) * time.Second)},
+		}
+	}
+
+	errorResponse := &apiErrorResponse{}
+	err = readAPIErrorResponse(resp, errorResponse)
+	if err == nil && errorResponse.isAbuseRateLimit() {
+		logger.Warningf("error reading 'Retry-After=%s' header from the '403 Forbidden' response, using default '%s': %s",
+			retryInHeader,
+			defaultSleep,
+			err,
+		)
+
+		return &ErrAbuseRateLimit{
+			errRetryLater{time.Now().Add(defaultSleep)},
+		}
+	}
+
+	logger.Warningf("403 Forbidden response got, but could not be read as an Abuse Rate Limit response")
+	return nil
+}
+
+// asErrRateLimit will return an ErrRateLimit if the Response 'X-RateLimit-Remaining' header is 0,
+// and the X-RateLimit-Reset' header contains a valid reset info
+func asErrRateLimit(resp *http.Response) *ErrRateLimit {
+	rateLimitResetHeader := resp.Header.Get("X-RateLimit-Reset")
+	rateLimitReset, err := strconv.Atoi(rateLimitResetHeader)
+	if err != nil {
+		return nil
+	}
+
+	rateLimitRemainingHeader := resp.Header.Get("X-RateLimit-Remaining")
+	rateLimitRemaining, err := strconv.Atoi(rateLimitRemainingHeader)
+	if err != nil {
+		return nil
+	}
+
+	if rateLimitRemaining == 0 {
+		return &ErrRateLimit{
+			errRetryLater{time.Unix(int64(rateLimitReset)+1, 0)},
+		}
+	}
+
+	return nil
+}
+
+// readAPIErrorResponse reads the response.Body into the passed errorResponse
+func readAPIErrorResponse(resp *http.Response, errorResponse *apiErrorResponse) error {
+	bodyContent, err := readResponseAndRestore(resp)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bodyContent, errorResponse)
+}

--- a/github/ratelimit_test.go
+++ b/github/ratelimit_test.go
@@ -1,0 +1,391 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/src-d/metadata-retrieval/testutils"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const defaultRateLimitReset = 1 * time.Second
+const defaultAbuseReset = 1 * time.Second
+const default403Reset = 2 * time.Second
+
+const defaultRequestBody = `{"content":"data"}`
+
+var testCases = map[string]response{
+	// regular answer
+	"/normal": response{
+		statusCode: http.StatusOK,
+		headers:    nil,
+		response:   apiResponse{Data: "success"},
+		err:        nil,
+	},
+	// proper ratelimit reset in defaultRateLimitReset
+	"/ratelimit_sleep": response{
+		statusCode: http.StatusOK,
+		headers:    rateLimitHeaders(defaultRateLimitReset),
+		response:   apiResponse{Data: "whatever"},
+		err:        nil,
+	},
+	// proper abuse reset in defaultRateLimitReset
+	"/abuse_sleep": response{
+		statusCode: http.StatusForbidden,
+		headers:    abuseHeaders(defaultAbuseReset),
+		response:   apiResponse{Data: "whatever"},
+		err:        nil,
+	},
+	// 403 with proper AbuseRateLimit body but without headers
+	"/abuse_no_headder": response{
+		statusCode: http.StatusForbidden,
+		headers:    nil,
+		response: apiResponse{
+			apiErrorResponse: apiErrorResponse{Message: "Found an abuse detection mechanism"},
+		},
+		err: nil,
+	},
+	// 403 without proper AbuseRateLimit body nor headers
+	"/forbidden_403": response{
+		statusCode: http.StatusForbidden,
+		headers:    nil,
+		response:   apiResponse{Data: "forbidden"},
+		err:        nil,
+	},
+	// returns a network error
+	"/network_error": response{
+		statusCode: http.StatusTeapot,
+		headers:    nil,
+		response:   apiResponse{},
+		err:        fmt.Errorf("network error"),
+	},
+}
+
+type response struct {
+	statusCode int
+	headers    func(time.Time) map[string]string
+	response   apiResponse
+	err        error
+}
+
+type apiResponse struct {
+	apiErrorResponse
+	Data string `json:"data,omitempty"`
+}
+
+func rateLimitHeaders(wait time.Duration) func(time.Time) map[string]string {
+	return func(when time.Time) map[string]string {
+		return map[string]string{
+			"X-RateLimit-Reset":     strconv.FormatInt(when.Add(wait).Unix(), 10),
+			"X-RateLimit-Remaining": "0",
+		}
+	}
+}
+
+func abuseHeaders(wait time.Duration) func(time.Time) map[string]string {
+	return func(when time.Time) map[string]string {
+		return map[string]string{
+			"Retry-After": strconv.FormatInt(int64(wait.Seconds()), 10),
+		}
+	}
+}
+
+func newResponse(content apiResponse, headers func(time.Time) map[string]string, statusCode int) (*http.Response, error) {
+	data, err := json.Marshal(content)
+	if err != nil {
+		return nil, err
+	}
+
+	respWriter := httptest.NewRecorder()
+	respWriter.WriteHeader(statusCode)
+	_, err = respWriter.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	response := respWriter.Result()
+
+	if headers != nil {
+		for k, v := range headers(time.Now()) {
+			response.Header.Set(k, v)
+		}
+	}
+
+	return response, err
+}
+
+func newRequest(url string) *http.Request {
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer([]byte(defaultRequestBody)))
+	return req
+}
+
+// gitHubTransportResponseMock avoids calling the network to get the response directly from testcases
+type gitHubTransportResponseMock struct {
+	lastRequest *http.Request
+}
+
+func (gh *gitHubTransportResponseMock) RoundTrip(req *http.Request) (*http.Response, error) {
+	gh.lastRequest = req
+	url := req.URL.String()
+	tc, ok := testCases[url]
+	if !ok {
+		return newResponse(apiResponse{}, nil, http.StatusOK)
+	}
+
+	if tc.err != nil {
+		return &http.Response{}, tc.err
+	}
+
+	return newResponse(tc.response, tc.headers, tc.statusCode)
+}
+func TestRateLimitSuite(t *testing.T) {
+	suite.Run(t, new(RateLimitSuite))
+}
+
+type RateLimitSuite struct {
+	suite.Suite
+	transport        *RateLimitTransport
+	loggerMock       *testutils.LoggerMock
+	ghResponseMocker *gitHubTransportResponseMock
+	require          *require.Assertions
+}
+
+func (s *RateLimitSuite) SetupSuite() {
+}
+
+func (s *RateLimitSuite) SetupTest() {
+	s.require = s.Require()
+	s.loggerMock = &testutils.LoggerMock{}
+	s.ghResponseMocker = &gitHubTransportResponseMock{}
+	s.transport = NewRateLimitTransport(s.ghResponseMocker, s.loggerMock)
+	s.transport.defaultAbuseSleep = default403Reset
+}
+
+func (s *RateLimitSuite) TearDownSuite() {
+}
+
+// TestNoLimit ensures that the regular case: no rate limit nor abuse, is not considered a RateLimit case
+func (s *RateLimitSuite) TestNoLimit() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+
+	content, err := ioutil.ReadAll(response.Body)
+	s.require.NoError(err)
+
+	var data apiResponse
+	err = json.Unmarshal(content, &data)
+	s.require.NoError(err)
+
+	s.Equal("success", data.Data)
+	s.Len(data.Errors, 0)
+}
+
+// TestRateLimitConsecutively ensures that hitting RateLimit twice, causes two waiting periods
+// it should log the RateLimitError, and wait till the lock expires
+// if the next Request hits the RateLimit again, it should do the same
+// if the next Request does not hit the RateLimit, it should return the response inmediately
+func (s *RateLimitSuite) TestRateLimitConsecutively() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/ratelimit_sleep"))
+	s.require.Error(err)
+	s.require.IsType(&ErrRateLimit{}, err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.NotNil(response)
+	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
+	s.Equal("", s.loggerMock.Next())
+
+	response, err = s.transport.RoundTrip(newRequest("/ratelimit_sleep"))
+	s.require.Error(err)
+	s.require.IsType(&ErrRateLimit{}, err)
+
+	t1 := time.Now()
+
+	elapsed = t1.Sub(t0)
+	s.True(elapsed > defaultRateLimitReset, "request took %s, but it should be, at least %s", elapsed, defaultRateLimitReset)
+	s.NotNil(response)
+	s.Contains(s.loggerMock.Next(), "rate limit reached, sleeping until")
+	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
+	s.Equal("", s.loggerMock.Next())
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	t2 := time.Now()
+
+	elapsed = t2.Sub(t1)
+	s.True(elapsed > defaultRateLimitReset, "request took %s, but it should be, at least %s", elapsed, defaultRateLimitReset)
+	s.Contains(s.loggerMock.Next(), "rate limit reached, sleeping until")
+	s.Equal("", s.loggerMock.Next())
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t2)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestRateLimitButWaitInsteadOfRetry ensures that RateLimitTransport does not block requests once the
+// previous RateLimit expired
+func (s *RateLimitSuite) TestRateLimitButWaitInsteadOfRetry() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/ratelimit_sleep"))
+	s.require.Error(err)
+	s.IsType(&ErrRateLimit{}, err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.NotNil(response)
+	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
+	s.Equal("", s.loggerMock.Next())
+
+	// The next Request is going to wait for more time than the previous RateLimit, so it should not be blocked by RateLimitTransport
+	time.Sleep(defaultRateLimitReset + time.Second)
+
+	t1 := time.Now()
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t1)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestAbuse ensures that hitting AbuseRateLimit, causes a wait period
+// it should log the AbuseRateLimit, and wait till the lock expires
+// if the next Request does not hit a RateLimit, it should return the response inmediately
+func (s *RateLimitSuite) TestAbuse() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/abuse_sleep"))
+	s.require.Error(err)
+	s.IsType(&ErrAbuseRateLimit{}, err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.NotNil(response)
+	s.Regexp("locking transport for [^;]+; abuse detection", s.loggerMock.Next())
+	s.Equal("", s.loggerMock.Next())
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t0)
+	s.True(elapsed > defaultAbuseReset, "request took %s, but it should be, at least %s", elapsed, defaultAbuseReset)
+	s.Contains(s.loggerMock.Next(), "rate limit reached, sleeping until")
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestAbuseWhithoutHeadersButWithProperBody ensures that a 403 Forbidden Response having a proper Abuse body is handled
+// as being an AbuseRateLimit, using defaultAbuseRetryAfter
+func (s *RateLimitSuite) TestAbuseWhithoutHeadersButWithProperBody() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/abuse_no_headder"))
+	s.require.Error(err)
+	s.IsType(&ErrAbuseRateLimit{}, err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.NotNil(response)
+	s.Contains(s.loggerMock.Next(), "error reading")
+	s.Regexp("locking transport for [^;]+; abuse detection", s.loggerMock.Next())
+	s.Equal("", s.loggerMock.Next())
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t0)
+	s.True(elapsed > default403Reset, "request took %s, but it should be, at least %s", elapsed, default403Reset)
+	s.Contains(s.loggerMock.Next(), "rate limit reached, sleeping until")
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestForbidden403NotHavingHeadersNorBody ensures that a 403 Forbidden Response, not having RateLimit Headers nor
+// proper Body, is ignored and not handled as an Abuse
+func (s *RateLimitSuite) TestForbidden403NotHavingHeadersNorBody() {
+	t0 := time.Now()
+
+	response, err := s.transport.RoundTrip(newRequest("/forbidden_403"))
+	s.require.NoError(err)
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal(http.StatusForbidden, response.StatusCode)
+	s.Contains(s.loggerMock.Next(), "could not be read as an Abuse Rate Limit response")
+	s.Equal("", s.loggerMock.Next())
+
+	content, err := ioutil.ReadAll(response.Body)
+	s.require.NoError(err)
+
+	var data apiResponse
+	err = json.Unmarshal(content, &data)
+	s.require.NoError(err)
+
+	s.Equal("forbidden", data.Data)
+	s.Len(data.Errors, 0)
+
+	response, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestFailedRequest ensures that a failed request is not interpreted as a RateLimit,
+// and the same error is returned as it was retrieved
+func (s *RateLimitSuite) TestFailedRequest() {
+	t0 := time.Now()
+
+	_, err := s.transport.RoundTrip(newRequest("/network_error"))
+	s.require.Error(err)
+	s.Equal("network error", err.Error())
+
+	elapsed := time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+
+	_, err = s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	elapsed = time.Now().Sub(t0)
+	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
+	s.Equal("", s.loggerMock.Next())
+}
+
+// TestRequestBodyIsKept ensures that the request sent through RateLimitTransport
+// is still readable and contains the same body when it calls its inner transport
+func (s *RateLimitSuite) TestRequestBodyIsKept() {
+	s.Nil(s.ghResponseMocker.lastRequest)
+
+	_, err := s.transport.RoundTrip(newRequest("/normal"))
+	s.require.NoError(err)
+
+	s.require.NotNil(s.ghResponseMocker.lastRequest)
+
+	receivedRequestContent, err := ioutil.ReadAll(s.ghResponseMocker.lastRequest.Body)
+	s.require.NoError(err)
+
+	s.Equal(defaultRequestBody, string(receivedRequestContent))
+}

--- a/testutils/logger.go
+++ b/testutils/logger.go
@@ -1,0 +1,51 @@
+package testutils
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-log.v1"
+)
+
+type LoggerMock struct {
+	out []string
+}
+
+func (l *LoggerMock) Next() string {
+	if len(l.out) == 0 {
+		return ""
+	}
+	first := l.out[0]
+	l.out[0] = ""
+	l.out = l.out[1:]
+	return first
+}
+
+func (l *LoggerMock) Debugf(format string, args ...interface{}) {
+	l.out = append(l.out, fmt.Sprintf(format, args...))
+	log.Debugf(format, args...)
+}
+
+func (l *LoggerMock) Errorf(err error, format string, args ...interface{}) {
+	arguments := append([]interface{}{err}, args)
+	errorFormat := fmt.Sprintf("Error %s; %s", err, format)
+	l.out = append(l.out, fmt.Sprintf(errorFormat, arguments...))
+	log.Errorf(err, format, args...)
+}
+
+func (l *LoggerMock) Infof(format string, args ...interface{}) {
+	l.out = append(l.out, fmt.Sprintf(format, args...))
+	log.Infof(format, args...)
+}
+
+func (l *LoggerMock) Warningf(format string, args ...interface{}) {
+	l.out = append(l.out, fmt.Sprintf(format, args...))
+	log.Warningf(format, args...)
+}
+
+func (l *LoggerMock) New(fields log.Fields) log.Logger {
+	return l
+}
+
+func (l *LoggerMock) With(fields log.Fields) log.Logger {
+	return l
+}


### PR DESCRIPTION
depends on https://github.com/src-d/metadata-retrieval/pull/49 [implement MultiToken]
fix https://github.com/src-d/metadata-retrieval/issues/3 [handle RateLimit errors]
fix https://github.com/src-d/metadata-retrieval/issues/18 [handle Abuse errors]

Changes grom `ghsync`
- the retry policy is implemented by `github.RetryTransport`, not by `github.RateLimitTransport`

Also needed:
- adf3a6b Enhance `retryTransport`:
  - retry also 500 errors
  - ensure it does not return errors but the ones from `Transport.RoundTrip`
  - log last error and the number of retries
- 65707c4 Restore the `Response`&`Request` when read from `Transport`
  - Since the `Request.Body` and `Response.Body` are read from any `transport.RoundTrip`,
it is needed to restore them before reusing it again;
otherwise, their `Body` won't be readable from other nested `Transport`.

### How does it work?

Trying to fetch an `org` with a GH token under an `AbuseRateLimmit` block, whose `quota` also expired:
1. `github.Downloader` tries to get the data, but GH answers with n `403, AbuseRateLimmit`,
1. the error is intercepted by `github.RateLimitTransport`, and the lock is enabled for the time specified by the headers from the `403, AbuseRateLimmit`; the error is bubbled up
1. the error is captured by `github.RetryTransport`, and retried
1. `github.RateLimitTransport` is locked, so it sleeps till the lock expires.
1. once the lock expired, the request is processed. In a regular situation, an `AbuseRateLimmit` will disappear, but in this example, it appeared a `RateLimmit` for that same query which is intercepted again by `github.RateLimitTransport`, and the lock is enabled again for the time specified by the headers from the `200, StatusOk`; the error is bubbled up
1. the error is captured by `github.RetryTransport`, and retried
1. `github.RateLimitTransport` is locked, so it sleeps till the lock expires.
1. once the lock expired, the request is processed with no new limits.

![trl3](https://user-images.githubusercontent.com/2437584/66830564-087ac400-ef56-11e9-9a0c-bb9c8e429a8d.png)



---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
