### PR TITLE
Make RateLimitTransport to log Abuse or RateLimit as Info

### DIFF
--- a/github/ratelimit.go
+++ b/github/ratelimit.go
@@ -71,7 +71,6 @@ func (rt *RateLimitTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	if errRateLimit := checkResponseRateLimit(resp, rt.logger, rt.defaultAbuseSleep); errRateLimit != nil {
 		rt.lockedUntil = errRateLimit.when()
-		rt.logger.Warningf("locking transport for %s; %s", errRateLimit.when().Sub(time.Now()), errRateLimit)
 		return resp, errRateLimit
 	}
 

--- a/github/ratelimit_test.go
+++ b/github/ratelimit_test.go
@@ -209,7 +209,6 @@ func (s *RateLimitSuite) TestRateLimitConsecutively() {
 	elapsed := time.Now().Sub(t0)
 	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
 	s.NotNil(response)
-	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
 	s.Equal("", s.loggerMock.Next())
 
 	response, err = s.transport.RoundTrip(newRequest("/ratelimit_sleep"))
@@ -222,7 +221,6 @@ func (s *RateLimitSuite) TestRateLimitConsecutively() {
 	s.True(elapsed > defaultRateLimitReset, "request took %s, but it should be, at least %s", elapsed, defaultRateLimitReset)
 	s.NotNil(response)
 	s.Contains(s.loggerMock.Next(), "rate limit reached, sleeping until")
-	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
 	s.Equal("", s.loggerMock.Next())
 
 	response, err = s.transport.RoundTrip(newRequest("/normal"))
@@ -255,7 +253,6 @@ func (s *RateLimitSuite) TestRateLimitButWaitInsteadOfRetry() {
 	elapsed := time.Now().Sub(t0)
 	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
 	s.NotNil(response)
-	s.Regexp("locking transport for [^;]+; API rate limit exceeded", s.loggerMock.Next())
 	s.Equal("", s.loggerMock.Next())
 
 	// The next Request is going to wait for more time than the previous RateLimit, so it should not be blocked by RateLimitTransport
@@ -284,7 +281,6 @@ func (s *RateLimitSuite) TestAbuse() {
 	elapsed := time.Now().Sub(t0)
 	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
 	s.NotNil(response)
-	s.Regexp("locking transport for [^;]+; abuse detection", s.loggerMock.Next())
 	s.Equal("", s.loggerMock.Next())
 
 	response, err = s.transport.RoundTrip(newRequest("/normal"))
@@ -309,7 +305,6 @@ func (s *RateLimitSuite) TestAbuseWhithoutHeadersButWithProperBody() {
 	s.True(elapsed < 500*time.Millisecond, "request took %s, but it should be almost instant", elapsed)
 	s.NotNil(response)
 	s.Contains(s.loggerMock.Next(), "error reading")
-	s.Regexp("locking transport for [^;]+; abuse detection", s.loggerMock.Next())
 	s.Equal("", s.loggerMock.Next())
 
 	response, err = s.transport.RoundTrip(newRequest("/normal"))


### PR DESCRIPTION
caused by #57 

Abuse (and RateLimit) are now logged as:
```
[2019-10-22T15:44:41.55352+02:00]  WARN locking transport for 59.999998742s; abuse detection mechanism triggered; retry after 2019-10-22 15:45:41.553492 +0200 CEST m=+923.886749598
[2019-10-22T15:44:41.553643+02:00]  WARN retrying in 49.08349ms; got abuse detection mechanism triggered; retry after 2019-10-22 15:45:41.553492 +0200 CEST m=+923.886749598
```

as [requested at slack [private]](https://src-d.slack.com/archives/C7TB5NEDN/p1571756905208600?thread_ts=1571752016.203700&cid=C7TB5NEDN), `RateLimitTransport` should log them with `info` level.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
