### PR TITLE
Expose github.Storer and use it in constructor

### DIFF
--- a/examples/cmd/testing/recordingscript.go
+++ b/examples/cmd/testing/recordingscript.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	memory := new(testutils.Memory)
-	downloader, err := github.NewMemoryDownloader(client, memory)
+	downloader, err := github.NewDownloader(client, memory)
 	if err != nil {
 		panic(err)
 	}

--- a/github/store/db.go
+++ b/github/store/db.go
@@ -17,6 +17,10 @@ type DB struct {
 	v  int
 }
 
+func NewDB(db *sql.DB) *DB {
+	return &DB{DB: db}
+}
+
 func (s *DB) Begin() error {
 	var err error
 	s.tx, err = s.DB.Begin()


### PR DESCRIPTION
I simplified the constructor a little while working on unified metadata PR.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
