### PR TITLE
Use postgres:10-alpine as in sourced-ce

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   postgres:
-    image: postgres:10
+    image: postgres:10-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-ghsync}


### PR DESCRIPTION
related to https://github.com/src-d/sourced-ce/pull/130

Use `postgres:10-alpine` as in [sourced-ce/docker-compose.yml#L138](https://github.com/src-d/sourced-ce/blob/master/docker-compose.yml#L138)

This would reduce disk and memory footprint.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
